### PR TITLE
Implementazione Outlook Calendar

### DIFF
--- a/templates/course.gohtml
+++ b/templates/course.gohtml
@@ -15,6 +15,9 @@
         <a class="btn btn-info bg-white join-item apple">
             Apple Calendar <span class="icon-[logos--apple] text-xl"></span>
         </a>
+        <a class="btn btn-info bg-white join-item outlook">
+            Outlook Calendar <span></span>
+        </a>
     </div>
 {{ end }}
 
@@ -66,6 +69,7 @@
 
 
             const webcalLink = `webcal://${url.host}${calPath}`
+            const link = '${url.host}${calPath}'
 
             pre.innerHTML = webcalLink;
             // Select all text on click
@@ -97,8 +101,12 @@
 
             const addToAppleBtn = el.getElementsByClassName("apple")[0]
             addToAppleBtn.href = webcalLink
+
+            const addToOutlookBtn = el.getElementsByClassName("outlook")[0]
+            addToOutlookBtn.href = 'https://outlook.office.com/calendar/addcalendar'
+            addToOutlookBtn.addEventListener("click", () => {
+                window.open(link)
+            })
         }
     </script>
 {{ end }}
-
-


### PR DESCRIPTION
Purtroppo Outlook non consente, a differenza di Google e Apple, di sfruttare il protocollo `webcal` per importare file `.ics` da un URL, o almeno non automaticamente. Per ora quindi l'idea sarebbe, una volta premuto il bottone Outlook, di scaricare il file `.ics` (da [qui](https://calendar.students.cs.unibo.it/cal/8009/1)) e di aprire Outlook nella sezione di aggiunta di un calendario (ovvero [qui](https://outlook.office.com/calendar/addcalendar)).

Non è molto, ma meglio che niente.


P.S. _Non ho avuto modo di testare le modifiche_.