### PR TITLE
fix: new regex for corsi.unibo

### DIFF
--- a/unibo_integ/course.go
+++ b/unibo_integ/course.go
@@ -63,7 +63,7 @@ func (c Course) GetCourseWebsiteId() (CourseId, error) {
 	return websiteId, nil
 }
 
-var reg = regexp.MustCompile(`<a href="https://corsi\.unibo\.it/(.+?)"`)
+var reg = regexp.MustCompile(`<a .* href="https://corsi\.unibo\.it/(.+?)"`)
 
 func (c Course) scrapeCourseWebsiteId() (CourseId, error) {
 


### PR DESCRIPTION
Aveva smesso di andare e facendo un po' di debug ho scoperto che il nuovo sito di unibo ha aggiunto un po' di attributi ai vari elementi:
```
<a class="umtrack" data-umc="corsolink" data-uma="source: Contatti" data-uml="Sito web del corso" href="https://corsi.unibo.it/laurea/IngegneriaInformatica/contatti">
```

Ora va :)