### PR TITLE
Cache filling with a thread

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.1
 
 require (
 	github.com/arran4/golang-ical v0.2.2
-	github.com/csunibo/unibo-go v0.0.11
+	github.com/csunibo/unibo-go v0.0.12
 	github.com/gin-contrib/multitemplate v0.0.0-20231211133547-5f8f48f9d29f
 	github.com/gin-contrib/size v0.0.0-20231211133737-500859255df8
 	github.com/gin-gonic/gin v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/csunibo/unibo-go v0.0.10 h1:UwFIvTpXMKZCOVoX564RmqQttXTTs5Xz5hCAjun8N
 github.com/csunibo/unibo-go v0.0.10/go.mod h1:h2+xnccHa7x48RNB6d07bpHQ01ozw4oihgDOlvVrJ9U=
 github.com/csunibo/unibo-go v0.0.11 h1:vCRbMepElEV61jFZw0TU7c0nEnIQg/d/4gXphPgK9R0=
 github.com/csunibo/unibo-go v0.0.11/go.mod h1:h2+xnccHa7x48RNB6d07bpHQ01ozw4oihgDOlvVrJ9U=
+github.com/csunibo/unibo-go v0.0.12 h1:tNcapp8PF53bRdOyy2ZldS/Wfk/N6fOGrdcg4KBbI90=
+github.com/csunibo/unibo-go v0.0.12/go.mod h1:h2+xnccHa7x48RNB6d07bpHQ01ozw4oihgDOlvVrJ9U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -326,7 +326,7 @@ func getSubjectsMapFromCourseAndCurricula(course *unibo_integ.Course, curricula 
 
 	// To get a curricula from a course we need fetch from the unibo API. Sometimes
 	// this could fail, so the curricula is nil. We need to check to avoid crashing
-	// program.
+	// the program.
 	if curricula == nil {
 		return nil, fmt.Errorf("curricula parameter is nil")
 	}

--- a/main.go
+++ b/main.go
@@ -324,6 +324,9 @@ func getSubjectsMapFromCourseAndCurricula(course *unibo_integ.Course, curricula 
 		return nil, fmt.Errorf("course parameter is nil")
 	}
 
+	// To get a curricula from a course we need fetch from the unibo API. Sometimes
+	// this could fail, so the curricula is nil. We need to check to avoid crashing
+	// program.
 	if curricula == nil {
 		return nil, fmt.Errorf("curricula parameter is nil")
 	}

--- a/main.go
+++ b/main.go
@@ -310,8 +310,10 @@ func filterTimetableBySubjects(t timetable.Timetable, codes []string) timetable.
 	return filtered
 }
 
-var subjectscacheExpirationTime = time.Hour * 4
-var subjectscache = cache.New(subjectscacheExpirationTime, time.Hour*6)
+var (
+	subjectscacheExpirationTime = time.Hour * 4
+	subjectscache 				= cache.New(subjectscacheExpirationTime, time.Hour*6)
+)
 
 // The return type is a map that for every year of the course map a curriculum
 // to a slice of subjects

--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ func main() {
 		log.Fatal().Err(err).Msg("Unable to open open data file")
 	}
 
+	go fillSubjectsCache(courses)
+
 	r := setupRouter(courses)
 
 	err = r.Run()
@@ -101,8 +103,6 @@ func setupRouter(courses unibo_integ.CoursesMap) *gin.Engine {
 	return r
 }
 
-var subjectscache = cache.New(time.Hour*1, time.Hour*5)
-
 func coursePage(courses unibo_integ.CoursesMap) func(c *gin.Context) {
 	return func(ctx *gin.Context) {
 		courseId := ctx.Param("id")
@@ -126,32 +126,12 @@ func coursePage(courses unibo_integ.CoursesMap) func(c *gin.Context) {
 		curricula, err := course.GetAllCurricula()
 		if err != nil {
 			_ = ctx.Error(fmt.Errorf("unable to retrieve curricula: %w", err))
-			curricula = map[int]curriculum.Curricula{}
+			curricula = nil
 		}
 
-		m := make(map[int]map[curriculum.Curriculum][]timetable.SimpleSubject)
-		for y, cs := range curricula {
-			m[y] = make(map[curriculum.Curriculum][]timetable.SimpleSubject)
-			for _, c := range cs {
-
-				var subjects []timetable.SimpleSubject
-				key := fmt.Sprintf("%d-%d-%s", course.Codice, y, c.Value)
-				if t, found := subjectscache.Get(key); found {
-					subjects = t.([]timetable.SimpleSubject)
-				} else {
-					courseTimetable, err := course.GetTimetable(y, c, nil)
-					if err != nil {
-						_ = ctx.Error(fmt.Errorf("unable to retrieve timetable for subjects: %w", err))
-						// Can't do much, maybe log the error?
-						continue
-					}
-
-					subjects = courseTimetable.GetSubjects()
-					subjectscache.Set(key, subjects, cache.DefaultExpiration)
-				}
-
-				m[y][c] = subjects
-			}
+		m, err := getSubjectsMapFromCourseAndCurricula(course, curricula)
+		if err != nil {
+			_ = ctx.Error(fmt.Errorf("unable to retrieve subjects: %w", err))
 		}
 
 		ctx.HTML(http.StatusOK, "course", gin.H{
@@ -328,4 +308,71 @@ func filterTimetableBySubjects(t timetable.Timetable, codes []string) timetable.
 		}
 	}
 	return filtered
+}
+
+var subjectscacheExpirationTime = time.Hour * 4
+var subjectscache = cache.New(subjectscacheExpirationTime, time.Hour*6)
+
+// The return type is a map that for every year of the course map a curriculum
+// to a slice of subjects
+func getSubjectsMapFromCourseAndCurricula(course *unibo_integ.Course, curricula map[int]curriculum.Curricula) (map[int]map[curriculum.Curriculum][]timetable.SimpleSubject, error) {
+	if course == nil {
+		return nil, fmt.Errorf("course parameter is nil")
+	}
+
+	if curricula == nil {
+		return nil, fmt.Errorf("curricula parameter is nil")
+	}
+
+	m := make(map[int]map[curriculum.Curriculum][]timetable.SimpleSubject)
+	for y, cs := range curricula {
+		m[y] = make(map[curriculum.Curriculum][]timetable.SimpleSubject)
+		for _, c := range cs {
+
+			var subjects []timetable.SimpleSubject
+			key := fmt.Sprintf("%d-%d-%s", course.Codice, y, c.Value)
+			if t, found := subjectscache.Get(key); found {
+				subjects = t.([]timetable.SimpleSubject)
+			} else {
+				courseTimetable, err := course.GetTimetable(y, c, nil)
+				if err != nil {
+					// Can't do much. We return nil so the caller can retry
+					return nil, fmt.Errorf("unable to retrieve timetable for subjects: %w", err)
+				}
+
+				subjects = courseTimetable.GetSubjects()
+				subjectscache.Set(key, subjects, cache.DefaultExpiration)
+			}
+
+			m[y][c] = subjects
+		}
+	}
+
+	return m, nil
+}
+
+// This functions calls getSubjectsMapFromCourseAndCurricula for every course,
+// so the cache is always full and users do not see a slow site
+func fillSubjectsCache(courses unibo_integ.CoursesMap) {
+	// This is to make sure everything is started
+	time.Sleep(time.Second * 5)
+
+	for _, course := range courses {
+		log.Debug().Int("course-code", course.Codice).Str("course-name", course.Descrizione).Msg("queried subjects")
+
+		curricula, err := course.GetAllCurricula()
+		if err != nil {
+			log.Err(err).Int("course-code", course.Codice).Str("course-name", course.Descrizione).Msg("Can't get curricula in workerfor course")
+			continue
+		}
+		_, err = getSubjectsMapFromCourseAndCurricula(&course, curricula)
+		if err != nil {
+			log.Err(err).Msg("Can't subjects in worker")
+			continue
+		}
+
+		time.Sleep(time.Second * 30)
+	}
+
+	time.Sleep(subjectscacheExpirationTime)
 }


### PR DESCRIPTION
Come già accennato in #18, il fatto che ora mostriamo la possibilità di filtrare le materie ha rallentato il sito. In particolare quando si entra in un corso è necessario estrarre le materia per ogni anno per ogni curriculum. Se le materie sono in cache questo è ovviamente molto veloce, se non lo sono può richiedere tanto tempo per corsi che hanno molti anni e molti curriculum.

La mia soluzione è quella di avere un worker in background che cicla sui corsi e riempie la cache delle materie.

Ho un po' testato e mi sembra funzionare, però è la prima volta che implemento qualcosa del genere e ho dei dubbi sulla sua efficacia per lunghi periodi di tempo. Ho paura che si sfasi con la cache il tempo e non riesca effettivamente a riempirla sempre. Mi sembra comunque sensato provare, al massimo il sito resta lento in certi momenti.

Ho anche aggiornato unibo-go per mostrare un messaggio di errore migliore in seguito a #21.